### PR TITLE
add an npm-script to scale unit note length, and fix Bosun Bill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
     "scripts": {
         "build": "./songs-to-json && pug-pack src",
+        "scaleL": "coffee src/transform.coffee scaleL",
         "dev": "nodemon -w src -w songs -i src/songs.json -i src/by-title.json -e '*' -x npm run build"
     },
     "devDependencies": {
+        "coffeescript": "^2.7.0",
         "nodemon": "^2.0.22",
         "pug-pack": "brewingcode/pug-pack"
+    },
+    "dependencies": {
+        "mathjs": "^11.10.0"
     }
 }

--- a/songs/bosun-bill.txt
+++ b/songs/bosun-bill.txt
@@ -6,8 +6,8 @@ T: Bosun Bill
 M: 2/4
 L: 1/16
 K: Eb
-G8 |: .c4 .G4 | c6 G2 | .A3.A ABA2 | G6 E2 | .F3.F FGF2 | E3D C3_D | D3D         | D2_D2=D2      |
-G8 | .c4 .G4 | c6 G2 | AGA2 B3A   | G6 E2 | FGA2 G3F   | Gcd2 e3c      | .[^F4d2] .[=F4G2] | c4 B3A |
+G8 |: .c4 .G4 | c6 G2 | .A3.A A2B2A2 | G6 E2 | .F3.F F2G2F2 | E3D C3_D | D3D         | D2_D2=D2      |
+G8 | .c4 .G4 | c6 G2 | A2G2A2 B3A   | G6 E2 | F2G2A2 G3F   | G2c2d2 e3c      | .[^F4d2] .[=F4G2] | c4 B3A |
 G4 G3A | B4 G3E | F3E D3C | B,6 B,2 | E4 E3F | G4 E4  | F6 FG | F6 G2  | A4 A3B | G4 E4       |
 F4 G4      | E8         | F6 FG       | =A4 c4 | B8         | A8 .B,2 | G6 GA | B4 G4 | (F8 | F8)  | (E6 E)F | G4 E4 |
 (D8 | D8)  | C4 C3D | E4 A4           | G4 F3G | E6 E2   | G3E B,3G   | F3E D3F    | E8    | D8  :|

--- a/songs/bosun-bill.txt
+++ b/songs/bosun-bill.txt
@@ -4,10 +4,11 @@ T: Bosun Bill
 %%notecolors 1
 %%notelabels 1
 M: 2/4
-L: 1/8
+L: 1/16
 K: Eb
-G4 |: .c2 .G2 | c3 G | .A3/2.A/2 ABA | G3 E | .F3/2.F/2 FGF | E3/2D/2 C3/2_D/2 | D3/2D/2         | D_D=D      |
-G4 | .c2 .G2 | c3 G | AGA B3/2A/2   | G3 E | FGA G3/2F/2   | Gcd e3/2c/2      | .[^F2d] .[=F2G] | c2 B3/2A/2 |
-G2 G3/2A/2 | B2 G3/2E/2 | F3/2E/2 D3/2C/2 | B,3 B, | E2 E3/2F/2 | G2 E2  | F3 F/2G/2 | F3 G  | A2 A3/2B/2 | G2 E2       |
-F2 G2      | E4         | F3 F/2G/2       | =A2 c2 | B4         | A4 .B, | G3 G/2A/2 | B2 G2 | (F4 | F4)  | (E3 E/2)F/2 | G2 E2 |
-(D4 | D4)  | C2 C3/2D/2 | E2 A2           | G2 F3/2G/2 | E3 E   | G3/2E/2 B,3/2G/2   | F3/2E/2 D3/2F/2    | E4    | D4  :|
+G8 |: .c4 .G4 | c6 G2 | .A3.A ABA2 | G6 E2 | .F3.F FGF2 | E3D C3_D | D3D         | D2_D2=D2      |
+G8 | .c4 .G4 | c6 G2 | AGA2 B3A   | G6 E2 | FGA2 G3F   | Gcd2 e3c      | .[^F4d2] .[=F4G2] | c4 B3A |
+G4 G3A | B4 G3E | F3E D3C | B,6 B,2 | E4 E3F | G4 E4  | F6 FG | F6 G2  | A4 A3B | G4 E4       |
+F4 G4      | E8         | F6 FG       | =A4 c4 | B8         | A8 .B,2 | G6 GA | B4 G4 | (F8 | F8)  | (E6 E)F | G4 E4 |
+(D8 | D8)  | C4 C3D | E4 A4           | G4 F3G | E6 E2   | G3E B,3G   | F3E D3F    | E8    | D8  :|
+

--- a/src/transform.coffee
+++ b/src/transform.coffee
@@ -1,0 +1,40 @@
+fs = require 'fs'
+math = require 'mathjs'
+
+die = ->
+    console.error "error:", arguments...
+    process?.exit(1)
+
+scale = (factor, m) ->
+    frac = m[2].replace /// ^/ ///, '1/' # no numerator implies 1
+    if frac is ''
+        frac = 1 # no fraction at all is identity
+    expr = "#{factor} * #{frac}"
+    try
+        r = math.fraction(math.evaluate(expr)).toFraction()
+        if r is '1'
+            r = ''
+        return m[1] + r
+    catch e
+        console.error 'scale error:', m[0], expr, e.message
+        return m[0]
+
+module.exports =
+    scaleL: (abc, factor) ->
+        abc or die "scaleL abc string is missing"
+        factor or die "scaleL factor is missing"
+
+        for line in abc.split(/\n/)
+            if m = line.match /// ^ (\s* L: \s* )(.*) ///i
+                console.log m[1] + math.fraction(math.evaluate("#{m[2]} / #{factor}")).toFraction()
+            else if line.match(/\S/) and not line.match(/// ^ \s* ( % | \w+: | \# ) ///)
+                console.log line.replace /// ([ abcdefg,' ]+) ([ \d / ]*) ///gi, (m...) -> scale factor, m
+            else
+                console.log line
+
+unless module.parent
+    [f, args...] = process.argv.slice(2)
+    f or die "first arg must be a function name"
+    switch f
+        when 'scaleL' then module.exports.scaleL fs.readFileSync('/dev/stdin').toString(), args...
+        else die "unknown function: #{f}"

--- a/src/transform.coffee
+++ b/src/transform.coffee
@@ -12,6 +12,7 @@ scale = (factor, m) ->
     expr = "#{factor} * #{frac}"
     try
         r = math.fraction(math.evaluate(expr)).toFraction()
+        #console.warn m[0], expr, r
         if r is '1'
             r = ''
         return m[1] + r
@@ -28,7 +29,7 @@ module.exports =
             if m = line.match /// ^ (\s* L: \s* )(.*) ///i
                 console.log m[1] + math.fraction(math.evaluate("#{m[2]} / #{factor}")).toFraction()
             else if line.match(/\S/) and not line.match(/// ^ \s* ( % | \w+: | \# ) ///)
-                console.log line.replace /// ([ abcdefg,' ]+) ([ \d / ]*) ///gi, (m...) -> scale factor, m
+                console.log line.replace /// ([ abcdefg ] [,']? ) ([ \d / ]*) ///gi, (m...) -> scale factor, m
             else
                 console.log line
 

--- a/src/transform.coffee
+++ b/src/transform.coffee
@@ -5,6 +5,7 @@ die = ->
     console.error "error:", arguments...
     process?.exit(1)
 
+# regex replacer function, m is the RegExp match object, and returns the replacement string
 scale = (factor, m) ->
     frac = m[2].replace /// ^/ ///, '1/' # no numerator implies 1
     if frac is ''


### PR DESCRIPTION
The unit note length is the `L:` line of ABC: https://abcnotation.com/wiki/abc:standard:v2.1#lunit_note_length

I honestly would have just `eval`'d this shit, because Javascript is awesome. If I didn't have to then convert that `eval` result back into a fraction, that would have worked. However, converting Javscript numbers into proper fractions is black magic best left to `mathjs`.

This is halfway between a Node CJS module and a browser `<script>` asset. If it's worth working into our UI, we can convert it all the way to a browser `<script>`.