### PR TITLE
Guitar tabs

### DIFF
--- a/songs/joli-rouge.txt
+++ b/songs/joli-rouge.txt
@@ -11,7 +11,7 @@ w: From France we get the Bran-dy, from Mar-ti-nique the rum
 w: She's called the Dread-nought Ci-der, she's pro-per and she's fine
 w: So turn your sails over ~ ~ and bring her hard to port
 w: So you can have a Mag-ners and pour it o-ver ice
-w: 2 2 2 12 2 2 2 2 2 12 0 12 2 2
+w: 2 2 2 12 2 2 2 2 2 12 0 12 2
 "Dm" f3 (f2 f) | "C" ed(c c2) d | "Dm" c d2 d2 c | "Am" (d3 d)de |
 w: Sweet red ~ Cab-er-net ~ from I- ta- ly does come. ~ But the fair
 w: And when the day is over sure I wish that she were mine. ~ ~ Or

--- a/src/index.pug
+++ b/src/index.pug
@@ -148,7 +148,7 @@ append body
                             [{
                                 instrument: "guitar",
                                 label: "Guitar (%T)",
-                                tuning: ["D,", "A,", "D", "G", "A", "d"],
+                                tuning: ["E,", "A,", "D", "G", "B", "e"],
                             }]
                     }
 

--- a/src/index.pug
+++ b/src/index.pug
@@ -54,6 +54,10 @@ append body
             input#show-lyrics(type="checkbox" checked)
         span &nbsp;&nbsp;&nbsp;
         label
+            span Show guitar tab
+            input#show-gtab(type="checkbox")
+        span &nbsp;&nbsp;&nbsp;
+        label
             span Transpose:
             input#transpose(type="number" min="-24" max="24" step="1" value="0")
         span &nbsp;
@@ -68,6 +72,10 @@ append body
     script: include abcjs-basic.js
     script
         :coffeescript
+            abcjsParams =
+                responsive: 'resize'
+                add_classes: true
+
             displayKey = ->
                 k = window.editor.tunes[0].getKeySignature()
                 if k.acc is 'b'
@@ -114,9 +122,7 @@ append body
                 window.editor = new ABCJS.Editor 'abc',
                     canvas_id: 'paper',
                     warnings_id: 'warnings'
-                    abcjsParams:
-                        responsive: 'resize'
-                        add_classes: true
+                    abcjsParams: abcjsParams
 
                 $('.dropdown-menu a').click ->
                     setSong byTitle[$(this).text()]
@@ -134,6 +140,17 @@ append body
 
                 $('#show-lyrics').on 'change', ->
                     setSong byTitle[document.title]
+
+                $('#show-gtab').on 'change', ->
+                    window.editor.paramChanged {
+                        ...abcjsParams
+                       tablature: if $(this).is(':checked')
+                            [{
+                                instrument: "guitar",
+                                label: "Guitar (%T)",
+                                tuning: ["D,", "A,", "D", "G", "A", "d"],
+                            }]
+                    }
 
                 params = new URLSearchParams(window.location.search)
                 file = params.get('file')

--- a/src/index.pug
+++ b/src/index.pug
@@ -144,7 +144,7 @@ append body
                 $('#show-gtab').on 'change', ->
                     window.editor.paramChanged {
                         ...abcjsParams
-                       tablature: if $(this).is(':checked')
+                        tablature: if $(this).is(':checked')
                             [{
                                 instrument: "guitar",
                                 label: "Guitar (%T)",


### PR DESCRIPTION
Closes #9 

<img width="1129" alt="image" src="https://github.com/brewingcode/shanties/assets/1566363/ef1b8e0d-3f01-464f-8992-add90dea8e32">

See [the tablature docs](https://paulrosen.github.io/abcjs/visual/tablature.html#fonts) for more: I'm not sure if the `DADGAD` tuning needs to be changed. I also imagine chords would be a useful thing to show, rather than the individual notes. I couldn't find those options after a quick glance: any ideas? @chrisglein  Is this sufficient?